### PR TITLE
We don't need to lint dependencies of carol with clippy

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -286,7 +286,7 @@
 
               clippy = craneLib.cargoClippy (commonArgs // {
                 # FIXME this abuses crane implementation detail to pipe things throgh clippy-sarif & sarif-fmt
-                cargoClippyExtraArgs = "--all-features --all-targets --message-format=json -- --deny warnings | clippy-sarif | tee clippy.sarif | sarif-fmt";
+                cargoClippyExtraArgs = "--no-deps --all-features --all-targets --message-format=json -- --deny warnings | clippy-sarif | tee clippy.sarif | sarif-fmt";
 
                 nativeBuildInputs = [
                   clippy-sarif


### PR DESCRIPTION
I think this speeds things up a little bit.