### PR TITLE
Simplify github workflow caching with magic-nix-cache action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,9 @@ env:
 
 on:
   push:
-    branches: [ "master" ]
+    branches: ["master"]
   pull_request:
-    branches: [ "master" ]
+    branches: ["master"]
 
 jobs:
   flake:
@@ -33,7 +33,7 @@ jobs:
         uses: mikepenz/action-junit-report@v3
         if: success() || failure()
         with:
-          report_paths: 'test_result/nextest/default/junit.xml' # as per .config/nextest.toml
+          report_paths: "test_result/nextest/default/junit.xml" # as per .config/nextest.toml
       - name: Clippy
         run: |
           system="$(nix eval --impure --raw --expr builtins.currentSystem)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,29 +16,10 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
-      - run: |
-          sudo mkdir -p /nix/var
-          sudo chown -R "${USER}:" /nix/
-      - name: Restore Nix Store From Github Cache
-        id: cache-nix
-        uses: actions/cache/restore@v3
-        with:
-          key: cache-nix-${{ runner.os }}-${{ hashFiles('flake.lock') }}-${{ hashFiles('Cargo.lock') }}
-          path: |
-            /nix/store/
-            /nix/var/nix/db/db.sqlite
-          restore-keys: |
-            cache-nix-${{ runner.os }}-${{ hashFiles('flake.lock') }}
-            cache-nix-${{ runner.os }}
-      - run: |
-          sudo chown root:root /nix/
-          sudo chown -R root:root /nix/var
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v1
-      - uses: cachix/cachix-action@v12
-        with:
-          name: carol
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+        uses: DeterminateSystems/nix-installer-action@v4
+      - name: Run the Magic Nix Cache
+        uses: DeterminateSystems/magic-nix-cache-action@v1
       - name: Test
         run: |
           system="$(nix eval --impure --raw --expr builtins.currentSystem)"
@@ -72,11 +53,3 @@ jobs:
       # - run: cat clippy.sarif
       - name: Run All Flake Checks
         run: nix flake check -L
-      - name: Save Nix Store Cache
-        if: steps.cache-nix.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v3
-        with:
-          key: ${{ steps.cache-nix.outputs.cache-primary-key }}
-          path: |
-            /nix/store/
-            /nix/var/nix/db/db.sqlite


### PR DESCRIPTION
See https://determinate.systems/posts/magic-nix-cache

It might make sense to reintroduce cachix, so CI builds populate a binary cache that people can use in their developer environments, but that has potential security implications so I'd rather it be in a separate pull request if we intend to use it like that.