### PR TITLE
[derive] Add automatic client generation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,7 @@
 [workspace]
 
+resolver = "2"
+
 members = [
     "example-guests/hello_world",
     "example-guests/bitmex_oracle",

--- a/crates/carol_core/src/lib.rs
+++ b/crates/carol_core/src/lib.rs
@@ -18,7 +18,7 @@ pub mod hex;
 mod macros;
 use sha2::{Digest, Sha256};
 
-#[derive(Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd, Default)]
 pub struct MachineId([u8; 32]);
 
 impl MachineId {
@@ -30,7 +30,7 @@ impl MachineId {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd, Default)]
 pub struct BinaryId([u8; 32]);
 
 impl BinaryId {

--- a/crates/carol_guest/src/client.rs
+++ b/crates/carol_guest/src/client.rs
@@ -1,0 +1,11 @@
+use carol_core::MachineId;
+
+pub trait Client {
+    type Error: From<bincode::error::DecodeError> + From<bincode::error::EncodeError>;
+    fn activate(
+        &self,
+        machine_id: MachineId,
+        method_name: &str,
+        input: &[u8],
+    ) -> Result<Vec<u8>, Self::Error>;
+}

--- a/crates/carol_guest/src/lib.rs
+++ b/crates/carol_guest/src/lib.rs
@@ -2,6 +2,7 @@
 extern crate alloc;
 
 pub use bincode;
+pub use carol_core;
 pub use carol_guest_derive::{activate, codec, machine};
 pub use serde;
 pub use serde_json;
@@ -19,9 +20,11 @@ pub mod bind {
 }
 
 pub mod bls;
+mod client;
 pub mod http;
 pub mod log;
 pub mod machines;
+pub use client::*;
 
 #[cfg(target_arch = "wasm32")]
 mod wasm;

--- a/crates/carol_guest_derive/src/machine.rs
+++ b/crates/carol_guest_derive/src/machine.rs
@@ -210,7 +210,7 @@ pub fn machine(input: proc_macro2::TokenStream) -> proc_macro2::TokenStream {
                 format!("#[machine] bincode encoding output of {method_name}");
             let method_name_str = method_name.to_string();
             match_arms.push(parse_quote_spanned! { sig_span => #method_name_str => {
-                let (__method_input, _) = bincode::decode_from_slice::<#struct_path, _>(&__input, bincode::config::standard()).expect(#input_decode_expect);
+                let (__method_input, _) = carol_guest::bincode::decode_from_slice::<#struct_path, _>(&__input, carol_guest::bincode::config::standard()).expect(#input_decode_expect);
                 #[allow(clippy::let_unit_value)]
                 let __output = #activate_call;
                 carol_guest::bincode::encode_to_vec(__output, carol_guest::bincode::config::standard()).expect(#encode_output_expect)
@@ -249,7 +249,7 @@ pub fn machine(input: proc_macro2::TokenStream) -> proc_macro2::TokenStream {
                 let call_struct = #call_struct;
                 let encoded_input = carol_guest::bincode::encode_to_vec(&call_struct, carol_guest::bincode::config::standard())?;
                 let encoded_output = self.client.activate(self.machine_id, #method_name_str, &encoded_input)?;
-                let (decoded_output,_) = bincode::decode_from_slice(&encoded_output, carol_guest::bincode::config::standard())?;
+                let (decoded_output,_) = carol_guest::bincode::decode_from_slice(&encoded_output, carol_guest::bincode::config::standard())?;
                 Ok(decoded_output)
             }};
 
@@ -279,12 +279,12 @@ pub fn machine(input: proc_macro2::TokenStream) -> proc_macro2::TokenStream {
         http_match_arms.push(parse_quote! { "/" => {
             match __method {
                 carol_guest::http::Method::Get => http::Response {
-                    headers: vec![("Content-Type".into(), "text/html".as_bytes().to_vec())],
+                    headers: vec![("Content-Type".into(), b"text/html".to_vec())],
                     body: #welcome_literal.to_vec(),
                     status: 200,
                 },
                 _ => http::Response {
-                    headers: vec![("Allow".to_string(), "GET".as_bytes().to_vec())],
+                    headers: vec![("Allow".to_string(), b"GET".to_vec())],
                     body: vec![],
                     status: 405,
                 }

--- a/crates/carol_guest_derive/src/machine.rs
+++ b/crates/carol_guest_derive/src/machine.rs
@@ -5,8 +5,8 @@ use syn::{
     punctuated::Punctuated,
     spanned::Spanned,
     token::{self, Brace},
-    Arm, Attribute, Expr, ExprMatch, ExprMethodCall, Field, Fields, FieldsNamed, Generics,
-    ImplItem, ItemStruct, LitStr, Path, Token, VisPublic,
+    Arm, Attribute, Expr, ExprMatch, ExprMethodCall, ExprStruct, Field, FieldValue, Fields,
+    FieldsNamed, Generics, ImplItem, ItemStruct, LitStr, Member, Path, Token, VisPublic,
 };
 
 use crate::call_list::HttpEndpoint;
@@ -23,9 +23,11 @@ pub fn machine(input: proc_macro2::TokenStream) -> proc_macro2::TokenStream {
     let mut match_arms: Vec<Arm> = vec![];
     let mut method_structs = vec![];
     let mut call_list = crate::call_list::ActivationList::new();
+    let mut client_methods = vec![];
 
     for item in &mut input.items {
         if let ImplItem::Method(method) = item {
+            let mut client_method = method.clone();
             let activate_attr = match method
                 .attrs
                 .iter()
@@ -59,19 +61,30 @@ pub fn machine(input: proc_macro2::TokenStream) -> proc_macro2::TokenStream {
                 named: Punctuated::default(),
             };
 
-            let mut inputs = method.sig.inputs.iter_mut().peekable();
+            let mut client_call_fields = Punctuated::new();
+
+            let mut inputs = method.sig.inputs.iter_mut().enumerate().peekable();
             let mut _has_receiver = false; //TODO use this to only pass in receiver if it's there
-            if let Some(syn::FnArg::Receiver(_)) = inputs.peek() {
+            if let Some((_, syn::FnArg::Receiver(_))) = inputs.peek() {
                 _has_receiver = true;
                 let _ = inputs.next();
             } else {
                 return quote_spanned!(sig_span => compile_error!("the first argument to an #[activate] method must be &self"));
             }
 
-            if let Some(syn::FnArg::Typed(fn_arg)) = inputs.peek() {
+            if let Some((index_of_cap, syn::FnArg::Typed(fn_arg))) = inputs.peek() {
                 if let arg @ syn::Pat::Ident(pat_ident) = &*fn_arg.pat {
                     let ident = pat_ident.ident.to_string();
                     if ident == "cap" || ident == "_cap" {
+                        client_method.sig.inputs = client_method
+                            .sig
+                            .inputs
+                            .clone()
+                            .into_iter()
+                            .enumerate()
+                            .filter(|(i, _)| i != index_of_cap)
+                            .map(|(_, input)| input)
+                            .collect();
                         let _ = inputs.next();
                     } else {
                         return quote_spanned!(arg.span() => compile_error!("the second argument after `&self` to an #[activate] method must be `cap`"));
@@ -81,7 +94,7 @@ pub fn machine(input: proc_macro2::TokenStream) -> proc_macro2::TokenStream {
             let mut http_doc_params: Vec<(String, String)> = vec![];
             let mut activate_call_args = Punctuated::new();
             activate_call_args.push(parse_quote! { &__ctx });
-            for fn_arg in inputs {
+            for (_, fn_arg) in inputs {
                 let span = fn_arg.span();
                 match fn_arg {
                     syn::FnArg::Typed(fn_arg) => match fn_arg.pat.as_mut() {
@@ -117,6 +130,14 @@ pub fn machine(input: proc_macro2::TokenStream) -> proc_macro2::TokenStream {
                                 ident: Some(pat_ident.ident.clone()),
                                 colon_token: Some(fn_arg.colon_token),
                                 ty: *fn_arg.ty.clone(),
+                            });
+
+                            let ident = &pat_ident.ident;
+                            client_call_fields.push(FieldValue {
+                                attrs: vec![],
+                                member: Member::Named(pat_ident.ident.clone()),
+                                colon_token: Some(fn_arg.colon_token),
+                                expr: parse_quote_spanned! { pat_ident.span() => #ident },
                             });
 
                             activate_call_args.push(parse_quote_spanned! { fn_arg.span() => __method_input.#fn_arg_ident });
@@ -194,6 +215,45 @@ pub fn machine(input: proc_macro2::TokenStream) -> proc_macro2::TokenStream {
                 let __output = #activate_call;
                 carol_guest::bincode::encode_to_vec(__output, carol_guest::bincode::config::standard()).expect(#encode_output_expect)
             }});
+
+            let output_span = client_method.sig.output.span();
+            client_method.sig.output = match client_method.sig.output {
+                syn::ReturnType::Default => {
+                    parse_quote_spanned! { output_span => -> Result<(), C::Error> }
+                }
+                syn::ReturnType::Type(_, ty) => {
+                    parse_quote_spanned! { output_span => -> Result<#ty, C::Error> }
+                }
+            };
+            for param in client_method.sig.inputs.iter_mut() {
+                let attrs = match param {
+                    syn::FnArg::Typed(param) => &mut param.attrs,
+                    syn::FnArg::Receiver(recv) => &mut recv.attrs,
+                };
+                attrs.retain(|attr| {
+                    attr.path.get_ident().map(|ident| ident.to_string())
+                        != Some("with_serde".into())
+                })
+            }
+
+            let call_struct = ExprStruct {
+                attrs: vec![],
+                path: parse_quote_spanned! { sig_span => super::#struct_path },
+                brace_token: token::Brace::default(),
+                fields: client_call_fields,
+                dot2_token: None,
+                rest: None,
+            };
+
+            client_method.block = parse_quote_spanned! {sig_span => {
+                let call_struct = #call_struct;
+                let encoded_input = carol_guest::bincode::encode_to_vec(&call_struct, carol_guest::bincode::config::standard())?;
+                let encoded_output = self.client.activate(self.machine_id, #method_name_str, &encoded_input)?;
+                let (decoded_output,_) = bincode::decode_from_slice(&encoded_output, carol_guest::bincode::config::standard())?;
+                Ok(decoded_output)
+            }};
+
+            client_methods.push(client_method);
         }
     }
 
@@ -257,16 +317,28 @@ pub fn machine(input: proc_macro2::TokenStream) -> proc_macro2::TokenStream {
     let binary_api = call_list.binary_api();
 
     let output = quote! {
+        #input
 
         pub mod #carol_mod {
             use super::*;
             #(#method_structs)*
         }
 
+        pub mod client {
+            use super::*;
+            pub struct Client<C> {
+                pub client: C,
+                pub machine_id: carol_guest::carol_core::MachineId,
+            }
+
+            impl<C: carol_guest::Client> Client<C> {
+                 #(#client_methods)*
+            }
+        }
+
         #[cfg(not(test))]
         carol_guest::set_machine!(#self_ty);
 
-        #input
 
         mod __machine_impl {
             use super::*;

--- a/crates/carol_guest_derive/tests/http_handler.rs
+++ b/crates/carol_guest_derive/tests/http_handler.rs
@@ -47,7 +47,7 @@ fn post_request() {
     let _response = Foo::handle_http(http::Request {
         method: http::Method::Post,
         uri: "/post_add".into(),
-        body: r#"{"lhs": 3, "rhs": 4}"#.as_bytes().to_vec(),
+        body: br#"{"lhs": 3, "rhs": 4}"#.to_vec(),
         headers: vec![],
     });
 }
@@ -80,7 +80,7 @@ fn custom_path_post() {
     Foo::handle_http(http::Request {
         method: http::Method::Post,
         uri: "/other/path".into(),
-        body: r#"{"lhs": 3, "rhs": 4}"#.as_bytes().to_vec(),
+        body: br#"{"lhs": 3, "rhs": 4}"#.to_vec(),
         headers: vec![],
     });
 }
@@ -90,7 +90,7 @@ fn post_request_invalid_params() {
     let response = Foo::handle_http(http::Request {
         method: http::Method::Post,
         uri: "/post_add".into(),
-        body: r#"{"lhs": 3, "rhs": "foo"}"#.as_bytes().to_vec(),
+        body: br#"{"lhs": 3, "rhs": "foo"}"#.to_vec(),
         headers: vec![],
     });
 
@@ -114,7 +114,7 @@ fn method_not_allowed() {
     let response = Foo::handle_http(http::Request {
         method: http::Method::Post,
         uri: "/get_add".into(),
-        body: r#"{"lhs": 3, "rhs": 4}"#.as_bytes().to_vec(),
+        body: br#"{"lhs": 3, "rhs": 4}"#.to_vec(),
         headers: vec![],
     });
 

--- a/crates/carol_guest_derive/tests/test-client.rs
+++ b/crates/carol_guest_derive/tests/test-client.rs
@@ -1,0 +1,67 @@
+#![allow(renamed_and_removed_lints, unknown_lints, disallowed_names)]
+use carol_guest_derive::{activate, codec, machine};
+use core::any::Any;
+
+#[codec]
+pub struct Thing;
+
+#[machine]
+impl Thing {
+    #[activate]
+    pub fn one(&self, _cap: &impl Any, lhs: u32, rhs: u32) -> u32 {
+        lhs + rhs
+    }
+
+    #[activate]
+    pub fn two(&self, _cap: &impl Any, lhs: u32, rhs: u32) -> u32 {
+        lhs + rhs
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    use carol_guest::carol_core::MachineId;
+
+    #[test]
+    fn client_receives_correct_name_and_data() {
+        struct TestClient;
+        struct Error;
+
+        impl From<bincode::error::DecodeError> for Error {
+            fn from(_: bincode::error::DecodeError) -> Self {
+                todo!()
+            }
+        }
+
+        impl From<bincode::error::EncodeError> for Error {
+            fn from(_: bincode::error::EncodeError) -> Self {
+                todo!()
+            }
+        }
+
+        impl carol_guest::Client for TestClient {
+            type Error = Error;
+
+            fn activate(
+                &self,
+                _: carol_guest::carol_core::MachineId,
+                method_name: &str,
+                input: &[u8],
+            ) -> Result<Vec<u8>, Self::Error> {
+                if method_name == "two" && input == [0x01, 0x02] {
+                    Ok(vec![0x03])
+                } else {
+                    Err(Error)
+                }
+            }
+        }
+
+        let client = super::client::Client {
+            client: TestClient,
+            machine_id: MachineId::default(),
+        };
+
+        assert!(matches!(client.two(1, 2), Ok(3)));
+    }
+}


### PR DESCRIPTION
So you can use the guest crate as a library and call remote instances of it. Doesn't yet add the actual impls of the trait to do this.

I want to add clients for both calling other machines and calling remote machine running on remote carol node.