### PR TITLE
[http] Return static bls key at /

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,6 +395,7 @@ dependencies = [
 name = "carol_http"
 version = "0.1.0"
 dependencies = [
+ "carol_bls",
  "carol_core",
  "hyper",
  "serde",

--- a/crates/carol_http/Cargo.toml
+++ b/crates/carol_http/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 carol_core.workspace = true
 serde.workspace = true
 hyper.workspace = true
+carol_bls.workspace = true
 
 [features]
 default = [ "std" ]

--- a/crates/carol_http/src/api.rs
+++ b/crates/carol_http/src/api.rs
@@ -3,6 +3,13 @@ use carol_core::{serde, BinaryId, MachineId};
 use hyper::{header, http::HeaderValue, HeaderMap, StatusCode};
 
 #[derive(serde::Serialize, serde::Deserialize)]
+pub struct Root {
+    pub static_public_key: carol_bls::PublicKey,
+}
+
+impl Response for Root {}
+
+#[derive(serde::Serialize, serde::Deserialize)]
 pub struct BinaryCreated {
     pub id: BinaryId,
 }


### PR DESCRIPTION
There was no other straightforward way to get it.

Custom HTML should be handled per machine and customized per HTTP request host.