### PR TITLE
Resolve host header names by CNAME lookup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,6 +145,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
 
 [[package]]
+name = "bech32"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -324,6 +330,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "url",
  "wit-component",
 ]
 
@@ -419,6 +426,7 @@ dependencies = [
 name = "carol_http"
 version = "0.1.0"
 dependencies = [
+ "bech32",
  "carol_bls",
  "carol_core",
  "hyper",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,16 @@ version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
 dependencies = [
- "gimli",
+ "gimli 0.27.3",
+]
+
+[[package]]
+name = "addr2line"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+dependencies = [
+ "gimli 0.28.0",
 ]
 
 [[package]]
@@ -30,39 +39,38 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.2"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "anstream"
-version = "0.3.2"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+checksum = "2ab91ebe16eb252986481c5b62f6098f3b698a45e34b5b98200cf20dd2484a44"
 dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
- "is-terminal",
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle"
-version = "1.0.1"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd"
+checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
+checksum = "317b9a89c1868f5ea6ff1d9539a69f45dffc21ce321ac1fd1160dfa48c8e2140"
 dependencies = [
  "utf8parse",
 ]
@@ -78,9 +86,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "1.0.1"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
+checksum = "f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628"
 dependencies = [
  "anstyle",
  "windows-sys",
@@ -88,25 +96,25 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.71"
+version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
+checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
 name = "arbitrary"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d098ff73c1ca148721f37baad5ea6a465a13f9573aba8641fbbbae8164a54e"
+checksum = "a2e1373abdaa212b704512ec2bd8b26bd0b7d5c3f70117411a5d9a451383c859"
 
 [[package]]
 name = "async-trait"
-version = "0.1.68"
+version = "0.1.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
+checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -116,10 +124,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
-name = "base64"
-version = "0.21.2"
+name = "backtrace"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
+checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+dependencies = [
+ "addr2line 0.21.0",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object 0.32.1",
+ "rustc-demangle",
+]
+
+[[package]]
+name = "base64"
+version = "0.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
 
 [[package]]
 name = "bincode"
@@ -172,9 +195,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.3.2"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dbe3c979c178231552ecba20214a8272df4e09f232a87aef4320cf06539aded"
+checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
 name = "bitmex_oracle"
@@ -234,36 +257,36 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.13.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
+checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "byteorder"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
 name = "camino"
-version = "1.1.4"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c530edf18f37068ac2d977409ed5cd50d53d73bc653c7647b48eb78976ac9ae2"
+checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbdb825da8a5df079a43676dbe042702f1707b1109f713a01420fbb4cc71fa27"
+checksum = "12024c4645c97566567129c204f65d5815a8c9aecf30fcbe682b2fe034996d36"
 dependencies = [
  "serde",
 ]
@@ -314,6 +337,7 @@ dependencies = [
  "carol_host",
  "carol_http",
  "clap",
+ "hickory-resolver",
  "hyper",
  "rand",
  "serde",
@@ -403,11 +427,12 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.79"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
 dependencies = [
  "jobserver",
+ "libc",
 ]
 
 [[package]]
@@ -418,13 +443,12 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.3.5"
+version = "4.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2686c4115cb0810d9a984776e197823d08ec94f176549a89a9efded477c456dc"
+checksum = "d04704f56c2cde07f43e8e2c154b43f216dc5c92fc98ada720177362f953b956"
 dependencies = [
  "clap_builder",
  "clap_derive",
- "once_cell",
 ]
 
 [[package]]
@@ -440,13 +464,12 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.3.5"
+version = "4.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e53afce1efce6ed1f633cf0e57612fe51db54a1ee4fd8f8503d078fe02d69ae"
+checksum = "0e231faeaca65ebd1ea3c737966bf858971cd38c3849107aa3ea7de90a804e45"
 dependencies = [
  "anstream",
  "anstyle",
- "bitflags 1.3.2",
  "clap_lex",
  "strsim",
  "terminal_size",
@@ -454,21 +477,21 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.3.2"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8cd2b2a819ad6eec39e8f1d6b53001af1e5469f8c177579cdaeb313115b825f"
+checksum = "0862016ff20d69b84ef8247369fabf5c008a7417002411897d40ee1f4532b873"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.38",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
+checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
 
 [[package]]
 name = "colorchoice"
@@ -496,6 +519,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
+
+[[package]]
 name = "cpp_demangle"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -506,27 +545,27 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03e69e28e9f7f77debdedbaafa2866e1de9ba56df55a8bd7cfc724c25a09987c"
+checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.97.1"
+version = "0.97.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c289b8eac3a97329a524e953b5fd68a8416ca629e1a37287f12d9e0760aadbc"
+checksum = "7aae6f552c4c0ccfb30b9559b77bc985a387d998e1736cbbe6b14c903f3656cf"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.97.1"
+version = "0.97.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bf07ba80f53fa7f7dc97b11087ea867f7ae4621cfca21a909eca92c0b96c7d9"
+checksum = "95551de96900cefae691ce895ff2abc691ae3a0b97911a76b45faf99e432937b"
 dependencies = [
  "bumpalo",
  "cranelift-bforest",
@@ -535,7 +574,7 @@ dependencies = [
  "cranelift-control",
  "cranelift-entity",
  "cranelift-isle",
- "gimli",
+ "gimli 0.27.3",
  "hashbrown 0.13.2",
  "log",
  "regalloc2",
@@ -545,42 +584,42 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.97.1"
+version = "0.97.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40a7ca088173130c5c033e944756e3e441fbf3f637f32b4f6eb70252580c6dd4"
+checksum = "36a3ad7b2bb03de3383f258b00ca29d80234bebd5130cb6ef3bae37ada5baab0"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.97.1"
+version = "0.97.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0114095ec7d2fbd658ed100bd007006360bc2530f57c6eee3d3838869140dbf9"
+checksum = "915918fee4142c85fb04bafe0bcd697e2fd6c15a260301ea6f8d2ea332a30e86"
 
 [[package]]
 name = "cranelift-control"
-version = "0.97.1"
+version = "0.97.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d56031683a55a949977e756d21826eb17a1f346143a1badc0e120a15615cd38"
+checksum = "37e447d548cd7f4fcb87fbd10edbd66a4f77966d17785ed50a08c8f3835483c8"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.97.1"
+version = "0.97.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6565198b5684367371e2b946ceca721eb36965e75e3592fad12fc2e15f65d7b"
+checksum = "9d8ab3352a1e5966968d7ab424bd3de8e6b58314760745c3817c2eec3fa2f918"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.97.1"
+version = "0.97.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25f28cc44847c8b98cb921e6bfc0f7b228f4d27519376fea724d181da91709a6"
+checksum = "1bffa38431f7554aa1594f122263b87c9e04abc55c9f42b81d37342ac44f79f0"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -590,15 +629,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.97.1"
+version = "0.97.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80b658177e72178c438f7de5d6645c56d97af38e17fcb0b500459007b4e05cc5"
+checksum = "84cef66a71c77938148b72bf006892c89d6be9274a08f7e669ff15a56145d701"
 
 [[package]]
 name = "cranelift-native"
-version = "0.97.1"
+version = "0.97.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf1c7de7221e6afcc5e13ced3b218faab3bc65b47eac67400046a05418aecd6a"
+checksum = "f33c7e5eb446e162d2d10b17fe68e1f091020cc2e4e38b5501c21099600b0a1b"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -607,9 +646,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.97.1"
+version = "0.97.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76b0d28ebe8edb6b503630c489aa4669f1e2d13b97bec7271a0fcb0e159be3ad"
+checksum = "632f7b64fa6a8c5b980eb6a17ef22089e15cb9f779f1ed3bd3072beab0686c09"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -617,7 +656,7 @@ dependencies = [
  "itertools",
  "log",
  "smallvec",
- "wasmparser",
+ "wasmparser 0.107.0",
  "wasmtime-types",
 ]
 
@@ -628,16 +667,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -684,6 +713,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
+
+[[package]]
 name = "debugid"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -693,10 +728,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "deunicode"
-version = "0.4.3"
+name = "deranged"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "850878694b7933ca4c9569d30a34b55031b9b139ee1fc7b94a527c4ef960d690"
+checksum = "0f32d04922c60427da6f9fef14d042d9edddef64cb9d4ce0d64d0685fbeb1fd3"
+dependencies = [
+ "powerfmt",
+ "serde",
+]
+
+[[package]]
+name = "deunicode"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71dbf1bf89c23e9cd1baf5e654f622872655f195b36588dc9dc38f7eda30758c"
+dependencies = [
+ "deunicode 1.4.1",
+]
+
+[[package]]
+name = "deunicode"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a1abaf4d861455be59f64fd2b55606cb151fce304ede7165f410243ce96bde6"
 
 [[package]]
 name = "digest"
@@ -746,15 +800,15 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "either"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.32"
+version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
+checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
 dependencies = [
  "cfg-if",
 ]
@@ -764,6 +818,18 @@ name = "entities"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5320ae4c3782150d900b79807611a59a99fc9a1d61d686faafc24b93fc8d7ca"
+
+[[package]]
+name = "enum-as-inner"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ffccbb6966c05b32ef8fbac435df276c4ae4d3dc55a8cd0eb9745e6c12f546a"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
+]
 
 [[package]]
 name = "env_logger"
@@ -779,24 +845,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "errno"
-version = "0.3.1"
+name = "equivalent"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
-dependencies = [
- "errno-dragonfly",
- "libc",
- "windows-sys",
-]
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
+name = "errno"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+checksum = "ac3e13f66a2f95e32a39eaa81f6b95d42878ca0e1db0c7543723dfe12557e860"
 dependencies = [
- "cc",
  "libc",
+ "windows-sys",
 ]
 
 [[package]]
@@ -807,9 +868,9 @@ checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fancy-regex"
-version = "0.7.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6b8560a05112eb52f04b00e5d3790c0dd75d9d980eb8a122fb23b92a623ccf"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
 dependencies = [
  "bit-set",
  "regex",
@@ -817,12 +878,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "1.9.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
-dependencies = [
- "instant",
-]
+checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "ff"
@@ -847,9 +905,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.26"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
+checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -898,6 +956,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -917,6 +986,7 @@ checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-task",
  "memchr",
  "pin-project-lite",
@@ -939,7 +1009,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27d12c0aed7f1e24276a241aadc4cb8ea9f83000f34bc062b7cc2d51e3b0fabd"
 dependencies = [
- "bitflags 2.3.2",
+ "bitflags 2.4.1",
  "debugid",
  "fxhash",
  "serde",
@@ -974,9 +1044,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
 dependencies = [
  "fallible-iterator",
- "indexmap",
+ "indexmap 1.9.3",
  "stable_deref_trait",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
 
 [[package]]
 name = "group"
@@ -991,9 +1067,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d357c7ae988e7d2182f7d7871d0b963962420b0678b0997ce7de72001aeab782"
+checksum = "91fc23aa11be92976ef4729127f1a74adf36d8436f7816b185d18df956790833"
 dependencies = [
  "bytes",
  "fnv",
@@ -1001,7 +1077,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap",
+ "indexmap 1.9.3",
  "slab",
  "tokio",
  "tokio-util",
@@ -1024,6 +1100,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dfda62a12f55daeae5015f81b0baea145391cb4520f86c248fc615d72640d12"
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1041,18 +1123,59 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.2.6"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
+checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+
+[[package]]
+name = "hickory-proto"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "091a6fbccf4860009355e3efc52ff4acf37a63489aad7435372d44ceeb6fbbcf"
 dependencies = [
- "libc",
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna",
+ "ipnet",
+ "once_cell",
+ "rand",
+ "rustls",
+ "rustls-pemfile",
+ "serde",
+ "thiserror",
+ "tinyvec",
+ "tokio",
+ "tokio-rustls",
+ "tracing",
+ "url",
 ]
 
 [[package]]
-name = "hermit-abi"
-version = "0.3.1"
+name = "hickory-resolver"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+checksum = "35b8f021164e6a984c9030023544c57789c51760065cd510572fedcfb04164e8"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-proto",
+ "lru-cache",
+ "once_cell",
+ "parking_lot",
+ "rand",
+ "rustls",
+ "serde",
+ "smallvec",
+ "thiserror",
+ "tokio",
+ "tokio-rustls",
+ "tracing",
+]
 
 [[package]]
 name = "http"
@@ -1084,9 +1207,9 @@ checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
 
 [[package]]
 name = "httpdate"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "humantime"
@@ -1096,9 +1219,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.26"
+version = "0.14.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab302d72a6f11a3b910431ff93aae7e773078c769f0a3ef15fb9ec692ed147d4"
+checksum = "ffb1cfd654a8219eaef89881fdb3bb3b1cdc5fa75ded05d6933b2b382e395468"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1111,7 +1234,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "socket2 0.4.9",
  "tokio",
  "tower-service",
  "tracing",
@@ -1120,10 +1243,11 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0646026eb1b3eea4cd9ba47912ea5ce9cc07713d105b1a14698f4e6433d348b7"
+checksum = "8d78e1e73ec14cf7375674f74d7dde185c8206fd9dea6fb6295e8a98098aaa97"
 dependencies = [
+ "futures-util",
  "http",
  "hyper",
  "rustls",
@@ -1159,12 +1283,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.12"
+name = "indexmap"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
 dependencies = [
- "cfg-if",
+ "equivalent",
+ "hashbrown 0.14.1",
 ]
 
 [[package]]
@@ -1173,26 +1298,25 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
- "hermit-abi 0.3.1",
+ "hermit-abi",
  "libc",
  "windows-sys",
 ]
 
 [[package]]
 name = "ipnet"
-version = "2.7.2"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12b6ee2129af8d4fb011108c73d99a1b83a85977f23b82460c0ae2e25bb4b57f"
+checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
+checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
- "hermit-abi 0.3.1",
- "io-lifetimes",
- "rustix",
+ "hermit-abi",
+ "rustix 0.38.19",
  "windows-sys",
 ]
 
@@ -1207,15 +1331,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
+checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "ittapi"
-version = "0.3.3"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e648c437172ce7d3ac35ca11a068755072054826fa455a916b43524fa4a62a7"
+checksum = "25a5c0b993601cad796222ea076565c5d9f337d35592f8622c753724f06d7271"
 dependencies = [
  "anyhow",
  "ittapi-sys",
@@ -1224,18 +1348,18 @@ dependencies = [
 
 [[package]]
 name = "ittapi-sys"
-version = "0.3.3"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9b32a4d23f72548178dde54f3c12c6b6a08598e25575c0d0fa5bd861e0dc1a5"
+checksum = "cb7b5e473765060536a660eed127f758cf1a810c73e49063264959c60d1727d9"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "jobserver"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
+checksum = "8c37f63953c4c63420ed5fd3d6d398c719489b9f872b9fa683262f8edd363c7d"
 dependencies = [
  "libc",
 ]
@@ -1263,15 +1387,15 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.146"
+version = "0.2.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
+checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
 
 [[package]]
 name = "libm"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "line-wrap"
@@ -1295,6 +1419,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f"
+
+[[package]]
 name = "lock_api"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1306,9 +1436,18 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+
+[[package]]
+name = "lru-cache"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
+dependencies = [
+ "linked-hash-map",
+]
 
 [[package]]
 name = "mach"
@@ -1343,17 +1482,17 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "memfd"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffc89ccdc6e10d6907450f753537ebc5c5d3460d2e4e62ea74bd571db62c0f9e"
+checksum = "b2cffa4ad52c6f791f4f8b15f0c05f9824b2ced1160e88cc393d64fff9a8ac64"
 dependencies = [
- "rustix",
+ "rustix 0.38.19",
 ]
 
 [[package]]
@@ -1412,9 +1551,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.15"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
 dependencies = [
  "autocfg",
  "libm",
@@ -1422,11 +1561,11 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.2.6",
+ "hermit-abi",
  "libc",
 ]
 
@@ -1438,7 +1577,16 @@ checksum = "03b4680b86d9cfafba8fc491dc9b6df26b68cf40e9e6cd73909194759a63c385"
 dependencies = [
  "crc32fast",
  "hashbrown 0.13.2",
- "indexmap",
+ "indexmap 1.9.3",
+ "memchr",
+]
+
+[[package]]
+name = "object"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
+dependencies = [
  "memchr",
 ]
 
@@ -1516,9 +1664,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.12"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
+checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "percent-encoding"
@@ -1528,9 +1676,9 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.9"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
 name = "pin-utils"
@@ -1551,12 +1699,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdc0001cfea3db57a2e24bc0d818e9e20e554b5f97fabb9bc231dc240269ae06"
 dependencies = [
  "base64",
- "indexmap",
+ "indexmap 1.9.3",
  "line-wrap",
  "quick-xml",
  "serde",
  "time",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1590,28 +1744,28 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.60"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
+checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "proptest"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e35c06b98bf36aba164cc17cb25f7e232f5c4aeea73baa14b8a9f0d92dbfa65"
+checksum = "7c003ac8c77cb07bb74f5f198bce836a689bcd5a42574612bf14d17bfd08c20e"
 dependencies = [
  "bit-set",
- "bitflags 1.3.2",
- "byteorder",
+ "bit-vec",
+ "bitflags 2.4.1",
  "lazy_static",
  "num-traits",
  "rand",
  "rand_chacha",
  "rand_xorshift",
- "regex-syntax 0.6.29",
+ "regex-syntax 0.7.5",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -1654,9 +1808,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.28"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
@@ -1708,9 +1862,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
+checksum = "9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1"
 dependencies = [
  "either",
  "rayon-core",
@@ -1718,14 +1872,12 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
+checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
 dependencies = [
- "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-utils",
- "num_cpus",
 ]
 
 [[package]]
@@ -1759,9 +1911,9 @@ dependencies = [
 
 [[package]]
 name = "regalloc2"
-version = "0.9.1"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12513beb38dd35aab3ac5f5b89fd0330159a0dc21d5309d75073011bbc8032b0"
+checksum = "ad156d539c879b7a24a363a2016d77961786e71f48f2e2fc8302a92abd2429a6"
 dependencies = [
  "hashbrown 0.13.2",
  "log",
@@ -1772,32 +1924,44 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.8.4"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
+checksum = "aaac441002f822bc9705a681810a4dd2963094b9ca0ddc41cb963a4c189189ea"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.2",
+ "regex-automata",
+ "regex-syntax 0.8.2",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5011c7e263a695dc8ca064cddb722af1be54e517a280b12a5356f98366899e5d"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.29"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.2"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "reqwest"
-version = "0.11.18"
+version = "0.11.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
+checksum = "046cd98826c46c2ac8ddecae268eb5c2e58628688a5fc7a2643704a73faba95b"
 dependencies = [
  "base64",
  "bytes",
@@ -1821,6 +1985,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "system-configuration",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -1867,23 +2032,36 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "0.37.20"
+version = "0.37.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b96e891d04aa506a6d1f318d2771bcb1c7dfda84e126660ace067c9b474bb2c0"
+checksum = "d4eb579851244c2c03e7c24f501c3432bed80b8f720af1d6e5b0e0f01555a035"
 dependencies = [
  "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.3.8",
+ "windows-sys",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "745ecfa778e66b2b63c88a61cb36e0eea109e803b0b86bf9879fbc77c70e86ed"
+dependencies = [
+ "bitflags 2.4.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.10",
  "windows-sys",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.21.2"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e32ca28af694bc1bbf399c33a516dbdf1c90090b8ab23c2bc24f834aa2247f5f"
+checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
 dependencies = [
  "log",
  "ring",
@@ -1893,18 +2071,18 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
+checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
 dependencies = [
  "base64",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.100.1"
+version = "0.101.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6207cd5ed3d8dca7816f8f3725513a34609c0c765bf652b8c3cb4cfd87db46b"
+checksum = "3c7d5dece342910d9ba34d259310cae3e0154b873b35408b787b59bce53d34fe"
 dependencies = [
  "ring",
  "untrusted",
@@ -1924,9 +2102,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.13"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
 name = "safemem"
@@ -1945,9 +2123,9 @@ dependencies = [
 
 [[package]]
 name = "scopeguard"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sct"
@@ -1961,38 +2139,38 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.17"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
+checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.164"
+version = "1.0.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
+checksum = "8e422a44e74ad4001bdc8eede9a4570ab52f71190e9c076d14369f38b9200537"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.164"
+version = "1.0.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
+checksum = "1e48d1f918009ce3145511378cf68d613e3b3d9137d67272562080d68a2b32d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.38",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.97"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdf3bf93142acad5821c99197022e170842cdbc1c30482b98750c688c640842a"
+checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
 dependencies = [
  "itoa",
  "ryu",
@@ -2013,11 +2191,11 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.21"
+version = "0.9.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9d684e3ec7de3bf5466b32bd75303ac16f0736426e5a4e0d6e489559ce1249c"
+checksum = "1a49e178e4452f45cb61d0cd8cebc1b0fafd3e41929e996cef79aa3aca91f574"
 dependencies = [
- "indexmap",
+ "indexmap 2.0.2",
  "itoa",
  "ryu",
  "serde",
@@ -2039,9 +2217,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.7"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2050,9 +2228,9 @@ dependencies = [
 
 [[package]]
 name = "sharded-slab"
-version = "0.1.4"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
@@ -2074,9 +2252,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
 dependencies = [
  "autocfg",
 ]
@@ -2093,14 +2271,14 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3bc762e6a4b6c6fcaade73e77f9ebc6991b676f88bb2358bddb56560f073373"
 dependencies = [
- "deunicode",
+ "deunicode 0.4.5",
 ]
 
 [[package]]
 name = "smallvec"
-version = "1.10.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "socket2"
@@ -2110,6 +2288,16 @@ checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "socket2"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4031e820eb552adee9295814c0ced9e5cf38ddf1e8b7d566d6de8e2538ea989e"
+dependencies = [
+ "libc",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2155,9 +2343,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.18"
+version = "2.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
+checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2166,26 +2354,45 @@ dependencies = [
 
 [[package]]
 name = "syntect"
-version = "5.0.0"
+version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6c454c27d9d7d9a84c7803aaa3c50cd088d2906fe3c6e42da3209aa623576a8"
+checksum = "e02b4b303bf8d08bfeb0445cba5068a3d306b6baece1d5582171a9bf49188f91"
 dependencies = [
  "bincode 1.3.3",
  "bitflags 1.3.2",
  "fancy-regex",
  "flate2",
  "fnv",
- "lazy_static",
  "once_cell",
  "onig",
  "plist",
- "regex-syntax 0.6.29",
+ "regex-syntax 0.7.5",
  "serde",
- "serde_derive",
  "serde_json",
  "thiserror",
  "walkdir",
  "yaml-rust",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -2196,61 +2403,60 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.8"
+version = "0.12.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1c7f239eb94671427157bd93b3694320f3668d4e1eff08c7285366fd777fac"
+checksum = "9d0e916b1148c8e263850e1ebcbd046f333e0683c724876bb0da63ea4373dc8a"
 
 [[package]]
 name = "tempfile"
-version = "3.6.0"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6"
+checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
 dependencies = [
- "autocfg",
  "cfg-if",
  "fastrand",
  "redox_syscall 0.3.5",
- "rustix",
+ "rustix 0.38.19",
  "windows-sys",
 ]
 
 [[package]]
 name = "termcolor"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
+checksum = "6093bad37da69aab9d123a8091e4be0aa4a03e4d601ec641c327398315f62b64"
 dependencies = [
  "winapi-util",
 ]
 
 [[package]]
 name = "terminal_size"
-version = "0.2.6"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e6bf6f19e9f8ed8d4048dc22981458ebcf406d67e94cd422e5ecd73d63b3237"
+checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
 dependencies = [
- "rustix",
+ "rustix 0.38.19",
  "windows-sys",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.40"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+checksum = "1177e8c6d7ede7afde3585fd2513e611227efd6481bd78d2e82ba1ce16557ed4"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.40"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+checksum = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -2265,11 +2471,13 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.22"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea9e1b3cf1243ae005d9e74085d4d542f3125458f3a81af210d901dcd7411efd"
+checksum = "c4a34ab300f2dee6e562c10a046fc05e358b29f9bf92277f30c3c8d82275f6f5"
 dependencies = [
+ "deranged",
  "itoa",
+ "powerfmt",
  "serde",
  "time-core",
  "time-macros",
@@ -2277,15 +2485,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.9"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "372950940a5f07bf38dbe211d7283c9e6d7327df53794992d293e534c733d09b"
+checksum = "4ad70d68dba9e1f8aceda7aa6711965dfec1cac869f311a51bd08b3a2ccbce20"
 dependencies = [
  "time-core",
 ]
@@ -2307,11 +2515,11 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.28.2"
+version = "1.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94d7b1cfd2aa4011f2de74c2c4c63665e27a71006b0a192dcd2710272e73dfa2"
+checksum = "4f38200e3ef7995e5ef13baec2f432a6da0aa9ac495b2c0e8f3b7eec2c92d653"
 dependencies = [
- "autocfg",
+ "backtrace",
  "bytes",
  "libc",
  "mio",
@@ -2319,7 +2527,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.5.4",
  "tokio-macros",
  "windows-sys",
 ]
@@ -2332,7 +2540,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -2347,9 +2555,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d"
+checksum = "1d68074620f57a0b21594d9735eb2e98ab38b17f80d3fcb189fca266771ca60d"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2376,11 +2584,10 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.37"
+version = "0.1.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+checksum = "ee2ef2af84856a50c1d430afce2fdded0a4ec7eda868db86409b4543df0797f9"
 dependencies = [
- "cfg-if",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -2388,20 +2595,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.38",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.31"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
  "valuable",
@@ -2446,9 +2653,9 @@ checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "typenum"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unarray"
@@ -2458,9 +2665,9 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicase"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
 dependencies = [
  "version_check",
 ]
@@ -2473,9 +2680,9 @@ checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.9"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-normalization"
@@ -2494,9 +2701,9 @@ checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
 name = "unicode-xid"
@@ -2512,9 +2719,9 @@ checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "unsafe-libyaml"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1865806a559042e51ab5414598446a5871b561d21b6764f2eabb0dd481d880a6"
+checksum = "f28467d3e1d3c6586d8f25fa243f544f5800fec42d97032474e17222c2b75cfa"
 
 [[package]]
 name = "untrusted"
@@ -2524,13 +2731,14 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
+checksum = "143b538f18257fac9cad154828a57c6bf5157e1aa604d4816b5995bf6de87ae5"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -2541,9 +2749,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "1.3.4"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa2982af2eec27de306107c027578ff7f423d65f7250e40ce0fea8f45248b81"
+checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
 
 [[package]]
 name = "valuable"
@@ -2574,9 +2782,9 @@ dependencies = [
 
 [[package]]
 name = "walkdir"
-version = "2.3.3"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
+checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
 dependencies = [
  "same-file",
  "winapi-util",
@@ -2618,7 +2826,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.38",
  "wasm-bindgen-shared",
 ]
 
@@ -2652,7 +2860,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.38",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2673,16 +2881,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ca90ba1b5b0a70d3d49473c5579951f3bddc78d47b59256d2f9d4922b150aca"
+dependencies = [
+ "leb128",
+]
+
+[[package]]
 name = "wasm-metadata"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36e5156581ff4a302405c44ca7c85347563ca431d15f1a773f12c9c7b9a6cdc9"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 1.9.3",
  "serde",
- "wasm-encoder",
- "wasmparser",
+ "wasm-encoder 0.29.0",
+ "wasmparser 0.107.0",
 ]
 
 [[package]]
@@ -2691,25 +2908,35 @@ version = "0.107.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29e3ac9b780c7dda0cac7a52a5d6d2d6707cc6e3451c9db209b6c758f40d7acb"
 dependencies = [
- "indexmap",
+ "indexmap 1.9.3",
+ "semver",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.115.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e06c0641a4add879ba71ccb3a1e4278fd546f76f1eafb21d8f7b07733b547cd5"
+dependencies = [
+ "indexmap 2.0.2",
  "semver",
 ]
 
 [[package]]
 name = "wasmprinter"
-version = "0.2.59"
+version = "0.2.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc960b30b84abca377768f3c62cff3a1c74db8c0f6759ed581827da0bd3a3fed"
+checksum = "e74458a9bc5cc9c7108abfa0fe4dc88d5abf1f3baf194df3264985f17d559b5e"
 dependencies = [
  "anyhow",
- "wasmparser",
+ "wasmparser 0.115.0",
 ]
 
 [[package]]
 name = "wasmtime"
-version = "10.0.1"
+version = "10.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd02b992d828b91efaf2a7499b21205fe4ab3002e401e3fe0f227aaeb4001d93"
+checksum = "1bc104ced94ff0a6981bde77a0bc29aab4af279914a4143b8d1af9fd4b2c9d41"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2718,10 +2945,10 @@ dependencies = [
  "cfg-if",
  "encoding_rs",
  "fxprof-processed-profile",
- "indexmap",
+ "indexmap 1.9.3",
  "libc",
  "log",
- "object",
+ "object 0.30.4",
  "once_cell",
  "paste",
  "psm",
@@ -2729,7 +2956,7 @@ dependencies = [
  "serde",
  "serde_json",
  "target-lexicon",
- "wasmparser",
+ "wasmparser 0.107.0",
  "wasmtime-cache",
  "wasmtime-component-macro",
  "wasmtime-component-util",
@@ -2745,18 +2972,18 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "10.0.1"
+version = "10.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284466ef356ce2d909bc0ad470b60c4d0df5df2de9084457e118131b3c779b92"
+checksum = "d2b28e5661a9b5f7610a62ab3c69222fa161f7bd31d04529e856461d8c3e706b"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-cache"
-version = "10.0.1"
+version = "10.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efc78cfe1a758d1336f447a47af6ec05e0df2c03c93440d70faf80e17fbb001e"
+checksum = "3f58ddfe801df3886feaf466d883ea37e941bcc6d841b9f644a08c7acabfe7f8"
 dependencies = [
  "anyhow",
  "base64",
@@ -2764,9 +2991,9 @@ dependencies = [
  "directories-next",
  "file-per-thread-logger",
  "log",
- "rustix",
+ "rustix 0.37.25",
  "serde",
- "sha2 0.10.7",
+ "sha2 0.10.8",
  "toml",
  "windows-sys",
  "zstd",
@@ -2774,9 +3001,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-macro"
-version = "10.0.1"
+version = "10.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e916103436a6d84faa4c2083e2e98612a323c2cc6147ec419124f67c764c9c"
+checksum = "39725d9633fb064bd3a6d83c5ea5077289256de0862d3d96295822edb13419c0"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -2789,15 +3016,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-util"
-version = "10.0.1"
+version = "10.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f20a5135ec5ef01080e674979b02d6fa5eebaa2b0c2d6660513ee9956a1bf624"
+checksum = "1153feafc824f95dc69472cb89a3396b3b05381f781a7508b01840f9df7b1a51"
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "10.0.1"
+version = "10.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1aa99cbf3f8edb5ad8408ba380f5ab481528ecd8a5053acf758e006d6727fd"
+checksum = "4fc1e39ce9aa0fa0b319541ed423960b06cfa7343eca1574f811ea34275739c2"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -2806,49 +3033,49 @@ dependencies = [
  "cranelift-frontend",
  "cranelift-native",
  "cranelift-wasm",
- "gimli",
+ "gimli 0.27.3",
  "log",
- "object",
+ "object 0.30.4",
  "target-lexicon",
  "thiserror",
- "wasmparser",
+ "wasmparser 0.107.0",
  "wasmtime-cranelift-shared",
  "wasmtime-environ",
 ]
 
 [[package]]
 name = "wasmtime-cranelift-shared"
-version = "10.0.1"
+version = "10.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cce31fd55978601acc103acbb8a26f81c89a6eae12d3a1c59f34151dfa609484"
+checksum = "2dd32739326690e51c76551d7cbf29d371e7de4dc7b37d2d503be314ab5b7d04"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
  "cranelift-control",
  "cranelift-native",
- "gimli",
- "object",
+ "gimli 0.27.3",
+ "object 0.30.4",
  "target-lexicon",
  "wasmtime-environ",
 ]
 
 [[package]]
 name = "wasmtime-environ"
-version = "10.0.1"
+version = "10.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f9e58e0ee7d43ff13e75375c726b16bce022db798d3a099a65eeaa7d7a544b"
+checksum = "32b60e4ae5c9ae81750d8bc59110bf25444aa1d9266c19999c3b64b801db3c73"
 dependencies = [
  "anyhow",
  "cranelift-entity",
- "gimli",
- "indexmap",
+ "gimli 0.27.3",
+ "indexmap 1.9.3",
  "log",
- "object",
+ "object 0.30.4",
  "serde",
  "target-lexicon",
  "thiserror",
- "wasm-encoder",
- "wasmparser",
+ "wasm-encoder 0.29.0",
+ "wasmparser 0.107.0",
  "wasmprinter",
  "wasmtime-component-util",
  "wasmtime-types",
@@ -2856,34 +3083,34 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-fiber"
-version = "10.0.1"
+version = "10.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14309cbdf2c395258b124a24757c727403070c0465a28bcc780c4f82f4bca5ff"
+checksum = "7dd40c8d869916ee6b1f3fcf1858c52041445475ca8550aee81c684c0eb530ca"
 dependencies = [
  "cc",
  "cfg-if",
- "rustix",
+ "rustix 0.37.25",
  "wasmtime-asm-macros",
  "windows-sys",
 ]
 
 [[package]]
 name = "wasmtime-jit"
-version = "10.0.1"
+version = "10.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0f2eaeb01bb67266416507829bd8e0bb60278444e4cbd048e280833ebeaa02"
+checksum = "655b23a10eddfe7814feb548a466f3f25aa4bb4f43098a147305c544a2de28e1"
 dependencies = [
- "addr2line",
+ "addr2line 0.19.0",
  "anyhow",
  "bincode 1.3.3",
  "cfg-if",
  "cpp_demangle",
- "gimli",
+ "gimli 0.27.3",
  "ittapi",
  "log",
- "object",
+ "object 0.30.4",
  "rustc-demangle",
- "rustix",
+ "rustix 0.37.25",
  "serde",
  "target-lexicon",
  "wasmtime-environ",
@@ -2895,20 +3122,20 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "10.0.1"
+version = "10.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f42e59d62542bfb73ce30672db7eaf4084a60b434b688ac4f05b287d497de082"
+checksum = "e46b7e98979a69d3df093076bde8431204e3c96a770e8d216fea365c627d88a4"
 dependencies = [
- "object",
+ "object 0.30.4",
  "once_cell",
- "rustix",
+ "rustix 0.37.25",
 ]
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "10.0.1"
+version = "10.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b49ceb7e2105a8ebe5614d7bbab6f6ef137a284e371633af60b34925493081f"
+checksum = "6fb1e7c68ede63dc7a98c3e473162954e224951854e229c8b4e74697fe17dbdd"
 dependencies = [
  "cfg-if",
  "libc",
@@ -2917,15 +3144,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-runtime"
-version = "10.0.1"
+version = "10.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a5de4762421b0b2b19e02111ca403632852b53e506e03b4b227ffb0fbfa63c2"
+checksum = "843e33bf9e0f0c57902c87a1dea1389cc23865c65f007214318dbdfcb3fd4ae5"
 dependencies = [
  "anyhow",
  "cc",
  "cfg-if",
  "encoding_rs",
- "indexmap",
+ "indexmap 1.9.3",
  "libc",
  "log",
  "mach",
@@ -2933,7 +3160,7 @@ dependencies = [
  "memoffset 0.8.0",
  "paste",
  "rand",
- "rustix",
+ "rustix 0.37.25",
  "sptr",
  "wasmtime-asm-macros",
  "wasmtime-environ",
@@ -2944,28 +3171,28 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-types"
-version = "10.0.1"
+version = "10.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbb7c138f797192f46afdd3ec16f85ef007c3bb45fa8e5174031f17b0be4c4a"
+checksum = "7473a07bebd85671bada453123e3d465c8e0a59668ff79f5004076e6a2235ef5"
 dependencies = [
  "cranelift-entity",
  "serde",
  "thiserror",
- "wasmparser",
+ "wasmparser 0.107.0",
 ]
 
 [[package]]
 name = "wasmtime-winch"
-version = "10.0.1"
+version = "10.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60160d8f7d2b301790730dac8ff25156c61d4fed79481e7074c21dd1283cfe2f"
+checksum = "351c9d4e60658dd0cf616c12c5508f86cc2cefcc0cff307eed0a31b23d3c0b70"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
- "gimli",
- "object",
+ "gimli 0.27.3",
+ "object 0.30.4",
  "target-lexicon",
- "wasmparser",
+ "wasmparser 0.107.0",
  "wasmtime-cranelift-shared",
  "wasmtime-environ",
  "winch-codegen",
@@ -2973,9 +3200,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wit-bindgen"
-version = "10.0.1"
+version = "10.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3334b0466a4d340de345cda83474d1d2c429770c3d667877971407672bc618a"
+checksum = "f114407efbd09e4ef67053b6ae54c16455a821ef2f6096597fcba83b7625e59c"
 dependencies = [
  "anyhow",
  "heck",
@@ -2984,21 +3211,21 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "60.0.0"
+version = "66.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd06cc744b536e30387e72a48fdd492105b9c938bb4f415c39c616a7a0a697ad"
+checksum = "93cb43b0ac6dd156f2c375735ccfd72b012a7c0a6e6d09503499b8d3cb6e6072"
 dependencies = [
  "leb128",
  "memchr",
  "unicode-width",
- "wasm-encoder",
+ "wasm-encoder 0.35.0",
 ]
 
 [[package]]
 name = "wat"
-version = "1.0.66"
+version = "1.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5abe520f0ab205366e9ac7d3e6b2fc71de44e32a2b58f2ec871b6b575bdcea3b"
+checksum = "e367582095d2903caeeea9acbb140e1db9c7677001efa4347c3687fd34fe7072"
 dependencies = [
  "wast",
 ]
@@ -3014,23 +3241,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
 name = "webpki-roots"
-version = "0.22.6"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
-dependencies = [
- "webpki",
-]
+checksum = "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc"
 
 [[package]]
 name = "winapi"
@@ -3050,9 +3264,9 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
 dependencies = [
  "winapi",
 ]
@@ -3065,17 +3279,17 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525fdd0d4e82d1bd3083bd87e8ca8014abfbdc5bf290d1d5371dac440d351e89"
+checksum = "b1bf2ac354be169bb201de7867b84f45d91d0ef812f67f11c33f74a7f5a24e56"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
- "gimli",
+ "gimli 0.27.3",
  "regalloc2",
  "smallvec",
  "target-lexicon",
- "wasmparser",
+ "wasmparser 0.107.0",
  "wasmtime-environ",
 ]
 
@@ -3090,9 +3304,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
@@ -3105,53 +3319,54 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "winreg"
-version = "0.10.1"
+version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
- "winapi",
+ "cfg-if",
+ "windows-sys",
 ]
 
 [[package]]
@@ -3160,7 +3375,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a628591b3905328e886462f75de3b2af1e546b19af5f4c359086b26bec29c4bd"
 dependencies = [
- "bitflags 2.3.2",
+ "bitflags 2.4.1",
  "wit-bindgen-rust-macro",
 ]
 
@@ -3206,7 +3421,7 @@ checksum = "78cce32dd08007af45dbaa00e225eb73d05524096f93933d7ecba852d50d8af3"
 dependencies = [
  "anyhow",
  "proc-macro2",
- "syn 2.0.18",
+ "syn 2.0.38",
  "wit-bindgen-core",
  "wit-bindgen-rust",
  "wit-component",
@@ -3220,11 +3435,11 @@ checksum = "7cbd4c7f8f400327c482c88571f373844b7889e61460650d650fc5881bb3575c"
 dependencies = [
  "anyhow",
  "bitflags 1.3.2",
- "indexmap",
+ "indexmap 1.9.3",
  "log",
- "wasm-encoder",
+ "wasm-encoder 0.29.0",
  "wasm-metadata",
- "wasmparser",
+ "wasmparser 0.107.0",
  "wit-parser",
 ]
 
@@ -3236,7 +3451,7 @@ checksum = "6daec9f093dbaea0e94043eeb92ece327bbbe70c86b1f41aca9bbfefd7f050f0"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 1.9.3",
  "log",
  "pulldown-cmark",
  "semver",
@@ -3289,11 +3504,10 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.8+zstd.1.5.5"
+version = "2.0.9+zstd.1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5556e6ee25d32df2586c098bbfa278803692a20d0ab9565e049480d52707ec8c"
+checksum = "9e16efa8a874a0481a574084d34cc26fdb3b99627480f785888deb6386506656"
 dependencies = [
  "cc",
- "libc",
  "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,4 +44,5 @@ lazy_static = "1"
 sha2 = { version = "0.9", default-features = false }
 rand_core = "0.6"
 rand = "0.8"
-
+bech32 = { version = "0.9" }
+url = { version = "2" }

--- a/crates/carlo/Cargo.toml
+++ b/crates/carlo/Cargo.toml
@@ -22,3 +22,4 @@ serde_json = { workspace = true }
 reqwest = { workspace = true }
 wit-component.workspace = true
 tokio = { version = "1", features = ["rt"] }
+url.workspace = true

--- a/crates/carlo/src/client.rs
+++ b/crates/carlo/src/client.rs
@@ -3,12 +3,12 @@ pub use carol_core::BinaryId;
 pub use carol_http::api::{BinaryCreated, MachineCreated};
 
 pub struct Client {
-    pub base: String,
+    pub base: reqwest::Url,
     http_client: reqwest::blocking::Client,
 }
 
 impl Client {
-    pub fn new(base: String) -> Self {
+    pub fn new(base: reqwest::Url) -> Self {
         Self {
             base,
             http_client: reqwest::blocking::Client::new(), // blocking::get() does builder().build()?
@@ -52,8 +52,9 @@ impl Client {
     }
 
     fn post(&self, path: &str) -> reqwest::blocking::RequestBuilder {
+        let url = self.base.join(path).expect("path is valid");
         self.http_client
-            .post(format!("{}/{}", self.base, path))
+            .post(url)
             .header(reqwest::header::ACCEPT, "application/json")
     }
 

--- a/crates/carol/Cargo.toml
+++ b/crates/carol/Cargo.toml
@@ -20,3 +20,4 @@ carol_core = { workspace = true, features = ["std"] }
 carol_bls = { workspace = true }
 serde_json = { workspace = true }
 rand = { workspace = true }
+hickory-resolver = { version = "0.24", features = ["dns-over-rustls", "serde-config", "tokio-runtime"], default-features = false }

--- a/crates/carol/src/config.rs
+++ b/crates/carol/src/config.rs
@@ -78,9 +78,6 @@ pub mod dns {
         /// machine id. Also anything CNAME'd to this domain would resolve to this.
         #[serde(default)]
         pub base_domain: Option<hickory_resolver::Name>,
-        /// Passthrough requests matching this domain to the HTTP API
-        #[serde(default)]
-        pub api_host: Option<hickory_resolver::Name>,
         #[serde(default)]
         pub hickory_conf: hickory_resolver::config::ResolverConfig,
         #[serde(default)]

--- a/crates/carol/src/config.rs
+++ b/crates/carol/src/config.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, path::PathBuf, str::FromStr};
+use std::str::FromStr;
 
 #[derive(serde::Deserialize, serde::Serialize)]
 pub struct Config {
@@ -20,15 +20,14 @@ impl Config {
 #[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
 pub struct HttpServerConfig {
     pub listen: std::net::SocketAddr,
-    #[serde(default)]
-    pub resources: HashMap<String, PathBuf>,
+    pub dns: dns::Config,
 }
 
 impl Default for HttpServerConfig {
     fn default() -> Self {
         Self {
             listen: std::net::SocketAddr::from_str("127.0.0.1:8000").unwrap(),
-            resources: Default::default(),
+            dns: Default::default(),
         }
     }
 }
@@ -65,4 +64,32 @@ impl From<Level> for tracing::level_filters::LevelFilter {
 #[derive(Debug, Clone, serde::Deserialize, serde::Serialize, Default)]
 pub struct LogConfig {
     pub level: Level,
+}
+
+pub mod dns {
+
+    #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Default)]
+    pub struct Config {
+        /// Matches requests that are directly for the carol host.
+        ///
+        /// e.g. 580048519c50c7d767edaeb1e582e2f766bc4eac4b7f0517d857bd8124bdf7.carol.computer
+        ///
+        /// If base domain was carol.computer then this would mean the hex is interpreted as a
+        /// machine id. Also anything CNAME'd to this domain would resolve to this.
+        #[serde(default)]
+        pub base_domain: Option<hickory_resolver::Name>,
+        /// Passthrough requests matching this domain to the HTTP API
+        #[serde(default)]
+        pub api_host: Option<hickory_resolver::Name>,
+        #[serde(default)]
+        pub hickory_conf: hickory_resolver::config::ResolverConfig,
+        #[serde(default)]
+        pub hickory_opts: hickory_resolver::config::ResolverOpts,
+    }
+
+    impl Config {
+        pub fn into_resolver(self) -> crate::http::resolver::Resolver {
+            crate::http::resolver::Resolver::new(self)
+        }
+    }
 }

--- a/crates/carol/src/http/mod.rs
+++ b/crates/carol/src/http/mod.rs
@@ -1,2 +1,3 @@
 pub use carol_http::api;
+pub mod resolver;
 pub mod server;

--- a/crates/carol/src/http/resolver.rs
+++ b/crates/carol/src/http/resolver.rs
@@ -1,0 +1,94 @@
+use std::{net::SocketAddr, str::FromStr};
+
+use carol_core::MachineId;
+use hickory_resolver::{
+    error::ResolveErrorKind,
+    proto::rr::{rdata::CNAME, RecordType},
+    Name, TokioAsyncResolver, TryParseIp,
+};
+use hyper::http::HeaderValue;
+
+#[derive(Clone)]
+pub struct Resolver {
+    inner: TokioAsyncResolver,
+    api_host: Option<Name>,
+    base_domain: Option<Name>,
+}
+
+pub enum Resolution {
+    Api,
+    Machine(MachineId),
+    Unknown,
+}
+
+impl Resolver {
+    pub fn new(config: crate::config::dns::Config) -> Self {
+        Self {
+            inner: TokioAsyncResolver::tokio(config.hickory_conf, config.hickory_opts),
+            api_host: config.api_host,
+            base_domain: config.base_domain,
+        }
+    }
+
+    pub async fn resolve_host(&self, host_header: &HeaderValue) -> anyhow::Result<Resolution> {
+        if self.api_host.is_none() {
+            return Ok(Resolution::Api);
+        }
+
+        let host = match host_header.to_str() {
+            Ok(host) => {
+                if let Ok(_) = SocketAddr::from_str(host) {
+                    return Ok(Resolution::Api);
+                }
+                if let Some(_) = host.try_parse_ip() {
+                    return Ok(Resolution::Api);
+                }
+                match Name::from_str(host).ok() {
+                    Some(host) => host,
+                    None => return Ok(Resolution::Unknown),
+                }
+            }
+            Err(_) => return Ok(Resolution::Unknown),
+        };
+
+        if Some(&host) == self.api_host.as_ref() {
+            return Ok(Resolution::Api);
+        }
+
+        if let Some(machine_id) = self.matches_machine(&host) {
+            return Ok(Resolution::Machine(machine_id));
+        }
+
+        let lookup = match self.inner.lookup(host, RecordType::CNAME).await {
+            Ok(lookup) => lookup,
+            Err(e) => match e.kind() {
+                ResolveErrorKind::NoRecordsFound { .. } => return Ok(Resolution::Unknown),
+                _ => Err(e)?,
+            },
+        };
+
+        for record in lookup.into_iter() {
+            if let Ok(CNAME(cname)) = record.into_cname() {
+                if let Some(machine_id) = self.matches_machine(&cname) {
+                    return Ok(Resolution::Machine(machine_id));
+                }
+            }
+        }
+
+        Ok(Resolution::Unknown)
+    }
+
+    fn matches_machine(&self, name: &Name) -> Option<MachineId> {
+        let mut labels = name.iter();
+        let first = labels.next().unwrap_or(&[]);
+        let first = String::from_utf8(first.to_vec()).ok()?;
+        let machine_id = MachineId::from_str(&first).ok()?;
+        let base_domain = Name::from_labels(labels).ok()?;
+
+        if self.base_domain == Some(base_domain) {
+            Some(machine_id)
+        } else {
+            None
+        }
+    }
+}

--- a/crates/carol/src/http/resolver.rs
+++ b/crates/carol/src/http/resolver.rs
@@ -39,10 +39,11 @@ impl Resolver {
 
         let host = match host_header.to_str() {
             Ok(host) => {
-                if let Ok(_) = SocketAddr::from_str(host) {
+                // If contacting an IP address etc just respond with API
+                if SocketAddr::from_str(host).is_ok() {
                     return Ok(Resolution::Api);
                 }
-                if let Some(_) = host.try_parse_ip() {
+                if host.try_parse_ip().is_some() {
                     return Ok(Resolution::Api);
                 }
                 match Name::from_str(host).ok() {

--- a/crates/carol/src/http/server.rs
+++ b/crates/carol/src/http/server.rs
@@ -298,6 +298,7 @@ impl Handler {
         match (req.method(), &segments[..]) {
             (&Method::GET, [""]) => Ok(build_response(&Root {
                 static_public_key: state.bls_keypair.public_key(),
+                base_domain: self.resolver.base_domain().map(ToString::to_string),
             })),
             (&Method::POST, ["binaries"]) => {
                 let body = slurp_request_body(&mut req).await?;

--- a/crates/carol/src/http/server.rs
+++ b/crates/carol/src/http/server.rs
@@ -225,6 +225,7 @@ impl Handler {
         }
     }
 
+    #[allow(clippy::type_complexity)]
     fn machine_components(
         &self,
         id: MachineId,
@@ -274,7 +275,7 @@ impl Handler {
                     .resolver
                     .resolve_host(host_header)
                     .await
-                    .map_err(|e| Problem::internal_server_error(e))?;
+                    .map_err(Problem::internal_server_error)?;
                 match resolution {
                     Resolution::Api => { /* carry on */ }
                     Resolution::Unknown => return Err(Problem::misdirected_request(host_header)),

--- a/crates/carol/src/http/server.rs
+++ b/crates/carol/src/http/server.rs
@@ -1,8 +1,9 @@
 use super::api::{self, *};
+use super::resolver::{Resolution, Resolver};
 use crate::config;
 use anyhow::{anyhow, Context};
-use carol_core::{BinaryId, MachineId};
-use carol_host::{GuestError, State};
+use carol_core::{hex, BinaryId, MachineId};
+use carol_host::{CompiledBinary, GuestError, State};
 use hyper::http::uri::PathAndQuery;
 use hyper::http::HeaderValue;
 use hyper::service::{make_service_fn, service_fn};
@@ -70,10 +71,38 @@ impl Problem {
         )
     }
 
+    pub fn misdirected_request(host: &HeaderValue) -> Self {
+        let host = host
+            .to_str()
+            .map(|x| x.to_string())
+            .unwrap_or_else(|_| format!("hex:\"{}\"", hex::encode(host.as_bytes())));
+        Self::new(
+            format!("HOST {host} couldn't be resovled to a machine"),
+            anyhow!("HOST {host} couldn't be resovled to a machine"),
+            StatusCode::MISDIRECTED_REQUEST,
+        )
+    }
+
     pub fn not_found(path: &str) -> Self {
         Self::new(
             format!("{} not found", path),
             anyhow!("resource not found: {}", path),
+            StatusCode::NOT_FOUND,
+        )
+    }
+
+    pub fn machine_not_found(machine_id: MachineId) -> Self {
+        Self::new(
+            format!("machine {machine_id} not found"),
+            anyhow!("machine {machine_id} not found"),
+            StatusCode::NOT_FOUND,
+        )
+    }
+
+    pub fn binary_not_found(binary_id: BinaryId) -> Self {
+        Self::new(
+            format!("binary {binary_id} not found"),
+            anyhow!("binary {binary_id} not found"),
             StatusCode::NOT_FOUND,
         )
     }
@@ -134,220 +163,6 @@ fn build_response<B: api::Response>(app_response: &B) -> Response<Body> {
     response
 }
 
-pub async fn dispatch(mut req: Request<Body>, state: State) -> Result<Response<Body>, Problem> {
-    let path = req.uri().path();
-    let segments = {
-        let mut segments = path.split('/');
-        // ignore first `/`
-        let _ = segments.next();
-        segments.collect::<Vec<_>>()
-    };
-    match (req.method(), &segments[..]) {
-        (&Method::GET, [""]) => Ok(build_response(&Root {
-            static_public_key: state.bls_keypair.public_key(),
-        })),
-        (&Method::POST, ["binaries"]) => {
-            let body = slurp_request_body(&mut req).await?;
-            let binary_id = BinaryId::new(&body);
-            let already_exists = state.exec.get_binary(binary_id).is_some();
-            let span = span!(
-                Level::INFO,
-                "POST /binaries",
-                binary_id = binary_id.to_string()
-            );
-            let _enter = span.enter();
-
-            if already_exists {
-                event!(Level::DEBUG, "already existing binary ignored");
-                let mut response = build_response(&BinaryCreated { id: binary_id });
-                *response.status_mut() = StatusCode::OK;
-                Ok(response)
-            } else {
-                let compiled_binary = state
-                    .exec
-                    .executor()
-                    .load_binary_from_wasm_binary(&body)
-                    .map_err(|e| {
-                        Problem::new(
-                            format!("Invalid WASM binary with id {}: {}", binary_id, e),
-                            e,
-                            StatusCode::BAD_REQUEST,
-                        )
-                    })?;
-
-                debug_assert_eq!(compiled_binary.binary_id(), binary_id);
-                state.exec.insert_binary(compiled_binary);
-                event!(Level::INFO, "new binary uploaded");
-                Ok(build_response(&BinaryCreated { id: binary_id }))
-            }
-        }
-        (method, ["binaries", binary_id]) => {
-            let binary_id = BinaryId::from_str(binary_id)
-                .map_err(|e| Problem::invalid_path_element::<BinaryId>(e.into(), binary_id))?;
-            let binary = state
-                .exec
-                .get_binary(binary_id)
-                .ok_or(Problem::not_found(path))?;
-
-            match method {
-                &Method::GET => {
-                    let carol_host::guest::BinaryApi { activations } = state
-                        .exec
-                        .executor()
-                        .get_binary_api(&binary)
-                        .await
-                        .map_err(|e| {
-                            Problem::bad_request("failed to retrieve API from binary", e)
-                        })?;
-                    let response = build_response(&carol_http::api::BinaryDescription {
-                        activations: activations
-                            .into_iter()
-                            .map(|carol_host::guest::ActivationDescription { name }| {
-                                (name, carol_http::api::AcivationDescription {})
-                            })
-                            .collect(),
-                    });
-                    Ok(response)
-                }
-                &Method::POST => {
-                    let params = slurp_request_body(&mut req).await?;
-                    let (already_exists, machine_id) = state.exec.insert_machine(binary_id, params);
-                    let mut response = build_response(&MachineCreated { id: machine_id });
-
-                    if already_exists {
-                        *response.status_mut() = StatusCode::OK;
-                    } else {
-                        event!(
-                            Level::INFO,
-                            machine_id = machine_id.to_string(),
-                            "machine created"
-                        );
-                    }
-                    Ok(response)
-                }
-                method => Err(Problem::method_not_allowed(
-                    path,
-                    method.as_str(),
-                    &["POST", "GET"],
-                )),
-            }
-        }
-        (method, ["machines", machine_id, trailing @ ..]) => {
-            let machine_id = MachineId::from_str(machine_id)
-                .map_err(|e| Problem::invalid_path_element::<MachineId>(e.into(), machine_id))?;
-            let (binary_id, params, compiled_binary) = {
-                let (binary_id, params) = state
-                    .exec
-                    .get_machine(machine_id)
-                    .ok_or(Problem::not_found(path))?;
-                let compiled_binary = state
-                    .exec
-                    .get_binary(binary_id)
-                    .ok_or(Problem::not_found(path))?;
-                (binary_id, params, compiled_binary)
-            };
-
-            match trailing {
-                &[] => match method {
-                    &Method::GET => Ok(build_response(&GetMachine {
-                        binary_id,
-                        params: params.as_ref(),
-                    })),
-                    _ => Err(Problem::method_not_allowed(path, method.as_str(), &["GET"])),
-                },
-                ["http", inner_path @ ..] => {
-                    // we need to direct /http to /http/ so relative urls work in the machine
-                    if inner_path.is_empty() && !req.uri().path().ends_with('/') {
-                        return Ok(Response::builder()
-                            .header(header::LOCATION, "http/")
-                            .status(StatusCode::PERMANENT_REDIRECT)
-                            .body(Body::empty())
-                            .unwrap());
-                    }
-                    let transformed_uri = {
-                        let mut parts = req.uri().clone().into_parts();
-                        let mut new_paq = format!("/{}", inner_path.join("/"));
-                        if let Some(paq) = parts.path_and_query {
-                            if let Some(query) = paq.query() {
-                                new_paq.extend(["?", query]);
-                            }
-                        }
-                        let new_paq = PathAndQuery::from_str(&new_paq)
-                            .with_context(|| {
-                                format!("trying to turn {new_paq} into a path and query")
-                            })
-                            .map_err(Problem::internal_server_error)?;
-                        parts.path_and_query = Some(new_paq);
-                        Uri::from_parts(parts)
-                            .context("trying to transform request URI for machine to handle")
-                            .map_err(Problem::internal_server_error)?
-                    };
-                    *req.uri_mut() = transformed_uri;
-                    let output = state
-                        .exec
-                        .executor()
-                        .machine_handle_http_request(
-                            state.clone(),
-                            compiled_binary.as_ref(),
-                            params.as_ref(),
-                            req,
-                        )
-                        .await
-                        .map_err(Problem::internal_server_error)?
-                        .map_err(Problem::guest_error)?;
-
-                    Ok(output)
-                }
-                ["activate", activation_name] => {
-                    let activation_name = activation_name.to_string();
-                    match method {
-                        &Method::POST => {
-                            let activation_input = slurp_request_body(&mut req).await?;
-                            let output = state
-                                .exec
-                                .executor()
-                                .activate_machine(
-                                    state.clone(),
-                                    compiled_binary.as_ref(),
-                                    params.as_ref(),
-                                    &activation_name,
-                                    &activation_input,
-                                )
-                                .await
-                                .map_err(|e| {
-                                    Problem::new(
-                                        format!(
-                                            "error occurred while trying to activate machine: {}",
-                                            e
-                                        ),
-                                        e,
-                                        StatusCode::INTERNAL_SERVER_ERROR,
-                                    )
-                                })?
-                                .map_err(|e| {
-                                    Problem::new(
-                                        format!("machine failed to complete activation: {}", e),
-                                        e.into(),
-                                        StatusCode::BAD_REQUEST,
-                                    )
-                                })?;
-                            Ok(Response::new(Body::from(output)))
-                        }
-                        method => Err(Problem::method_not_allowed(
-                            path,
-                            method.as_str(),
-                            &["POST"],
-                        )),
-                    }
-                }
-                _ => Err(Problem::not_found(path)),
-            }
-        }
-        (method, ["machines"]) => Err(Problem::method_not_allowed(path, method.as_str(), &[])),
-        _ => Err(Problem::not_found(path)),
-    }
-}
-
 async fn slurp_request_body(req: &mut Request<Body>) -> Result<Vec<u8>, Problem> {
     let body_stream = req.body_mut();
     let mut buf = Vec::with_capacity(body_stream.size_hint().upper().unwrap_or(0) as usize);
@@ -371,45 +186,25 @@ async fn slurp_request_body(req: &mut Request<Body>) -> Result<Vec<u8>, Problem>
 #[derive(Clone)]
 pub struct Handler {
     state: State,
-    resource_map: Arc<HashMap<String, Vec<u8>>>,
+    resolver: Resolver,
 }
 
 impl Handler {
     async fn handle(self, req: Request<Body>) -> Result<Response<Body>, Infallible> {
-        if let Some(resource_path) = req.uri().path().strip_prefix("/resources/") {
-            return self.handle_resource_request(resource_path).await;
-        }
-        self._handle(req).await
-    }
-    async fn handle_resource_request(self, path: &str) -> Result<Response<Body>, Infallible> {
-        let span = span!(Level::DEBUG, "resource handler", resource = path);
-        let _enter = span.enter();
-        match self.resource_map.get(path) {
-            Some(resource) => {
-                event!(Level::DEBUG, "resource found");
-                let mut res = Response::builder().status(200);
-                if path.ends_with(".css") {
-                    res = res.header("Content-Type", "text/css");
-                }
-                Ok(res.body(Body::from(resource.clone())).expect("infallible"))
-            }
-            None => {
-                event!(Level::INFO, "resource not found");
-                Ok(Response::builder()
-                    .status(404)
-                    .body(Body::empty())
-                    .expect("infallible"))
-            }
-        }
-    }
-    async fn _handle(self, req: Request<Body>) -> Result<Response<Body>, Infallible> {
+        let host = req
+            .headers()
+            .get(header::HOST)
+            .and_then(|host| host.to_str().ok())
+            .unwrap_or("<unable-to-decode>");
         let span = span!(
             Level::INFO,
             "HTTP",
             method = req.method().as_str(),
-            uri = req.uri().to_string()
+            uri = req.uri().to_string(),
+            host = host,
         );
-        match dispatch(req, self.state).instrument(span.clone()).await {
+
+        match self.dispatch(req).instrument(span.clone()).await {
             Ok(res) => Ok(res),
             Err(problem) => {
                 let _enter = span.enter();
@@ -429,34 +224,274 @@ impl Handler {
             }
         }
     }
+
+    fn machine_components(
+        &self,
+        id: MachineId,
+    ) -> Result<(BinaryId, Arc<Vec<u8>>, Arc<CompiledBinary>), Problem> {
+        let (binary_id, params) = self
+            .state
+            .exec
+            .get_machine(id)
+            .ok_or(Problem::machine_not_found(id))?;
+        let compiled_binary = self
+            .state
+            .exec
+            .get_binary(binary_id)
+            .ok_or(Problem::binary_not_found(binary_id))?;
+        Ok((binary_id, params, compiled_binary))
+    }
+
+    async fn http_request_to_machine(
+        &self,
+        id: MachineId,
+        request: Request<Body>,
+    ) -> Result<Response<Body>, Problem> {
+        let (_, params, compiled_binary) = self.machine_components(id)?;
+        let output = self
+            .state
+            .exec
+            .executor()
+            .machine_handle_http_request(
+                self.state.clone(),
+                compiled_binary.as_ref(),
+                params.as_ref(),
+                request,
+            )
+            .await
+            .map_err(Problem::internal_server_error)?
+            .map_err(Problem::guest_error)?;
+
+        Ok(output)
+    }
+
+    pub async fn dispatch(&self, mut req: Request<Body>) -> Result<Response<Body>, Problem> {
+        let state = &self.state;
+
+        match req.headers().get(header::HOST) {
+            Some(host_header) => {
+                let resolution = self
+                    .resolver
+                    .resolve_host(host_header)
+                    .await
+                    .map_err(|e| Problem::internal_server_error(e))?;
+                match resolution {
+                    Resolution::Api => { /* carry on */ }
+                    Resolution::Unknown => return Err(Problem::misdirected_request(host_header)),
+                    Resolution::Machine(machine_id) => {
+                        return self.http_request_to_machine(machine_id, req).await
+                    }
+                }
+            }
+            None => { /* assume it's for API */ }
+        }
+
+        let path = req.uri().path();
+
+        let segments = {
+            let mut segments = path.split('/');
+            // ignore first `/`
+            let _ = segments.next();
+            segments.collect::<Vec<_>>()
+        };
+
+        match (req.method(), &segments[..]) {
+            (&Method::GET, [""]) => Ok(build_response(&Root {
+                static_public_key: state.bls_keypair.public_key(),
+            })),
+            (&Method::POST, ["binaries"]) => {
+                let body = slurp_request_body(&mut req).await?;
+                let binary_id = BinaryId::new(&body);
+                let already_exists = state.exec.get_binary(binary_id).is_some();
+                let span = span!(
+                    Level::INFO,
+                    "POST /binaries",
+                    binary_id = binary_id.to_string()
+                );
+                let _enter = span.enter();
+
+                if already_exists {
+                    event!(Level::DEBUG, "already existing binary ignored");
+                    let mut response = build_response(&BinaryCreated { id: binary_id });
+                    *response.status_mut() = StatusCode::OK;
+                    Ok(response)
+                } else {
+                    let compiled_binary = state
+                        .exec
+                        .executor()
+                        .load_binary_from_wasm_binary(&body)
+                        .map_err(|e| {
+                            Problem::new(
+                                format!("Invalid WASM binary with id {}: {}", binary_id, e),
+                                e,
+                                StatusCode::BAD_REQUEST,
+                            )
+                        })?;
+
+                    debug_assert_eq!(compiled_binary.binary_id(), binary_id);
+                    state.exec.insert_binary(compiled_binary);
+                    event!(Level::INFO, "new binary uploaded");
+                    Ok(build_response(&BinaryCreated { id: binary_id }))
+                }
+            }
+            (method, ["binaries", binary_id]) => {
+                let binary_id = BinaryId::from_str(binary_id)
+                    .map_err(|e| Problem::invalid_path_element::<BinaryId>(e.into(), binary_id))?;
+                let binary = state
+                    .exec
+                    .get_binary(binary_id)
+                    .ok_or(Problem::binary_not_found(binary_id))?;
+
+                match method {
+                    &Method::GET => {
+                        let carol_host::guest::BinaryApi { activations } = state
+                            .exec
+                            .executor()
+                            .get_binary_api(&binary)
+                            .await
+                            .map_err(|e| {
+                                Problem::bad_request("failed to retrieve API from binary", e)
+                            })?;
+                        let response = build_response(&carol_http::api::BinaryDescription {
+                            activations: activations
+                                .into_iter()
+                                .map(|carol_host::guest::ActivationDescription { name }| {
+                                    (name, carol_http::api::AcivationDescription {})
+                                })
+                                .collect(),
+                        });
+                        Ok(response)
+                    }
+                    &Method::POST => {
+                        let params = slurp_request_body(&mut req).await?;
+                        let (already_exists, machine_id) =
+                            state.exec.insert_machine(binary_id, params);
+                        let mut response = build_response(&MachineCreated { id: machine_id });
+
+                        if already_exists {
+                            *response.status_mut() = StatusCode::OK;
+                        } else {
+                            event!(
+                                Level::INFO,
+                                machine_id = machine_id.to_string(),
+                                "machine created"
+                            );
+                        }
+                        Ok(response)
+                    }
+                    method => Err(Problem::method_not_allowed(
+                        path,
+                        method.as_str(),
+                        &["POST", "GET"],
+                    )),
+                }
+            }
+            (method, ["machines", machine_id, trailing @ ..]) => {
+                let machine_id = MachineId::from_str(machine_id).map_err(|e| {
+                    Problem::invalid_path_element::<MachineId>(e.into(), machine_id)
+                })?;
+
+                match trailing {
+                    &[] => match method {
+                        &Method::GET => {
+                            let (binary_id, params, _) = self.machine_components(machine_id)?;
+                            Ok(build_response(&GetMachine {
+                                binary_id,
+                                params: params.as_ref(),
+                            }))
+                        }
+                        _ => Err(Problem::method_not_allowed(path, method.as_str(), &["GET"])),
+                    },
+                    ["http", inner_path @ ..] => {
+                        // we need to direct /http to /http/ so relative urls work in the machine
+                        if inner_path.is_empty() && !req.uri().path().ends_with('/') {
+                            return Ok(Response::builder()
+                                .header(header::LOCATION, "http/")
+                                .status(StatusCode::PERMANENT_REDIRECT)
+                                .body(Body::empty())
+                                .unwrap());
+                        }
+                        let transformed_uri = {
+                            let mut parts = req.uri().clone().into_parts();
+                            let mut new_paq = format!("/{}", inner_path.join("/"));
+                            if let Some(paq) = parts.path_and_query {
+                                if let Some(query) = paq.query() {
+                                    new_paq.extend(["?", query]);
+                                }
+                            }
+                            let new_paq = PathAndQuery::from_str(&new_paq)
+                                .with_context(|| {
+                                    format!("trying to turn {new_paq} into a path and query")
+                                })
+                                .map_err(Problem::internal_server_error)?;
+                            parts.path_and_query = Some(new_paq);
+                            Uri::from_parts(parts)
+                                .context("trying to transform request URI for machine to handle")
+                                .map_err(Problem::internal_server_error)?
+                        };
+                        *req.uri_mut() = transformed_uri;
+
+                        self.http_request_to_machine(machine_id, req).await
+                    }
+                    ["activate", activation_name] => {
+                        let (_, params, compiled_binary) = self.machine_components(machine_id)?;
+                        let activation_name = activation_name.to_string();
+                        match method {
+                            &Method::POST => {
+                                let activation_input = slurp_request_body(&mut req).await?;
+                                let output = state
+                                    .exec
+                                    .executor()
+                                    .activate_machine(
+                                        state.clone(),
+                                        compiled_binary.as_ref(),
+                                        params.as_ref(),
+                                        &activation_name,
+                                        &activation_input,
+                                    )
+                                    .await
+                                    .map_err(|e| {
+                                        Problem::new(
+                                            format!(
+                                                "error occurred while trying to activate machine: {}",
+                                                e
+                                            ),
+                                            e,
+                                            StatusCode::INTERNAL_SERVER_ERROR,
+                                        )
+                                    })?
+                                    .map_err(|e| {
+                                        Problem::new(
+                                            format!("machine failed to complete activation: {}", e),
+                                            e.into(),
+                                            StatusCode::BAD_REQUEST,
+                                        )
+                                    })?;
+                                Ok(Response::new(Body::from(output)))
+                            }
+                            method => Err(Problem::method_not_allowed(
+                                path,
+                                method.as_str(),
+                                &["POST"],
+                            )),
+                        }
+                    }
+                    _ => Err(Problem::not_found(path)),
+                }
+            }
+            (method, ["machines"]) => Err(Problem::method_not_allowed(path, method.as_str(), &[])),
+            _ => Err(Problem::not_found(path)),
+        }
+    }
 }
 
 pub fn start(
     config: config::HttpServerConfig,
     state: State,
 ) -> anyhow::Result<(SocketAddr, impl Future<Output = ()> + Send + Sync + 'static)> {
-    let mut resource_map: HashMap<String, Vec<u8>> = config
-        .resources
-        .into_iter()
-        .map(|(uri_path, file_path)| {
-            Ok((
-                uri_path,
-                std::fs::read(&file_path)
-                    .context(format!("trying to read {}", file_path.display()))?,
-            ))
-        })
-        .collect::<anyhow::Result<_>>()?;
-
-    resource_map
-        .entry("guest-default.css".into())
-        .or_insert_with(|| {
-            event!(Level::DEBUG, "using guest-default.css from carol build");
-            include_bytes!("../../resources/guest-default.css").to_vec()
-        });
-    let resource_map = Arc::new(resource_map);
     let handler = Handler {
         state,
-        resource_map,
+        resolver: config.dns.into_resolver(),
     };
 
     // And a MakeService to handle each connection...

--- a/crates/carol_bls/src/lib.rs
+++ b/crates/carol_bls/src/lib.rs
@@ -115,7 +115,7 @@ mod test {
 
     proptest! {
         #[test]
-        fn sign_verify(sk in any::<[u8;64]>(), message in any::<[u8;32]>(), machine_id in any::<[u8;31]>()) {
+        fn sign_verify(sk in any::<[u8;64]>(), message in any::<[u8;32]>(), machine_id in any::<[u8;32]>()) {
             let sk = Scalar::from_bytes_wide(&sk);
             let kp = KeyPair::new(sk);
             let machine_id = MachineId::from_bytes(machine_id);

--- a/crates/carol_bls/src/lib.rs
+++ b/crates/carol_bls/src/lib.rs
@@ -115,7 +115,7 @@ mod test {
 
     proptest! {
         #[test]
-        fn sign_verify(sk in any::<[u8;64]>(), message in any::<[u8;32]>(), machine_id in any::<[u8;32]>()) {
+        fn sign_verify(sk in any::<[u8;64]>(), message in any::<[u8;32]>(), machine_id in any::<[u8;31]>()) {
             let sk = Scalar::from_bytes_wide(&sk);
             let kp = KeyPair::new(sk);
             let machine_id = MachineId::from_bytes(machine_id);

--- a/crates/carol_core/src/lib.rs
+++ b/crates/carol_core/src/lib.rs
@@ -19,7 +19,7 @@ mod macros;
 use sha2::{Digest, Sha256};
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd, Default)]
-pub struct MachineId([u8; 31]);
+pub struct MachineId([u8; 32]);
 
 impl MachineId {
     pub fn new(binary_id: BinaryId, params: &[u8]) -> Self {
@@ -27,8 +27,8 @@ impl MachineId {
         hash.update(binary_id.as_ref());
         hash.update(params);
         let bytes: [u8; 32] = hash.finalize().into();
-        let mut truncated = [0u8; 31];
-        truncated.copy_from_slice(&bytes[0..31]);
+        let mut truncated = [0u8; 32];
+        truncated.copy_from_slice(&bytes[0..32]);
         Self(truncated)
     }
 }
@@ -44,8 +44,8 @@ impl BinaryId {
     }
 }
 
-impl AsRef<[u8; 31]> for MachineId {
-    fn as_ref(&self) -> &[u8; 31] {
+impl AsRef<[u8; 32]> for MachineId {
+    fn as_ref(&self) -> &[u8; 32] {
         &self.0
     }
 }
@@ -58,13 +58,13 @@ impl AsRef<[u8; 32]> for BinaryId {
 
 crate::impl_fromstr_deserialize! {
     name => "machine id",
-    fn from_bytes(bytes: [u8;31]) -> MachineId {
+    fn from_bytes(bytes: [u8;32]) -> MachineId {
         MachineId(bytes)
     }
 }
 
 crate::impl_display_debug_serialize! {
-    fn to_bytes(machine_id: &MachineId) -> [u8;31] {
+    fn to_bytes(machine_id: &MachineId) -> [u8;32] {
         machine_id.0
     }
 }

--- a/crates/carol_core/src/lib.rs
+++ b/crates/carol_core/src/lib.rs
@@ -19,14 +19,17 @@ mod macros;
 use sha2::{Digest, Sha256};
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd, Default)]
-pub struct MachineId([u8; 32]);
+pub struct MachineId([u8; 31]);
 
 impl MachineId {
     pub fn new(binary_id: BinaryId, params: &[u8]) -> Self {
         let mut hash = Sha256::default();
         hash.update(binary_id.as_ref());
         hash.update(params);
-        Self(hash.finalize().into())
+        let bytes: [u8; 32] = hash.finalize().into();
+        let mut truncated = [0u8; 31];
+        truncated.copy_from_slice(&bytes[0..31]);
+        Self(truncated)
     }
 }
 
@@ -41,8 +44,8 @@ impl BinaryId {
     }
 }
 
-impl AsRef<[u8; 32]> for MachineId {
-    fn as_ref(&self) -> &[u8; 32] {
+impl AsRef<[u8; 31]> for MachineId {
+    fn as_ref(&self) -> &[u8; 31] {
         &self.0
     }
 }
@@ -55,13 +58,13 @@ impl AsRef<[u8; 32]> for BinaryId {
 
 crate::impl_fromstr_deserialize! {
     name => "machine id",
-    fn from_bytes(bytes: [u8;32]) -> MachineId {
+    fn from_bytes(bytes: [u8;31]) -> MachineId {
         MachineId(bytes)
     }
 }
 
 crate::impl_display_debug_serialize! {
-    fn to_bytes(machine_id: &MachineId) -> [u8;32] {
+    fn to_bytes(machine_id: &MachineId) -> [u8;31] {
         machine_id.0
     }
 }

--- a/crates/carol_host/src/lib.rs
+++ b/crates/carol_host/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::redundant_closure_call)]
 mod host_bindings;
 mod state;
 pub use state::*;

--- a/crates/carol_http/Cargo.toml
+++ b/crates/carol_http/Cargo.toml
@@ -10,6 +10,7 @@ carol_core.workspace = true
 serde.workspace = true
 hyper.workspace = true
 carol_bls.workspace = true
+bech32.workspace = true
 
 [features]
 default = [ "std" ]

--- a/crates/carol_http/src/api.rs
+++ b/crates/carol_http/src/api.rs
@@ -5,6 +5,7 @@ use hyper::{header, http::HeaderValue, HeaderMap, StatusCode};
 #[derive(serde::Serialize, serde::Deserialize)]
 pub struct Root {
     pub static_public_key: carol_bls::PublicKey,
+    pub base_domain: Option<String>,
 }
 
 impl Response for Root {}

--- a/crates/carol_http/src/host_header.rs
+++ b/crates/carol_http/src/host_header.rs
@@ -1,0 +1,16 @@
+use alloc::{string::String, vec::Vec};
+use bech32::{FromBase32, ToBase32};
+use carol_core::MachineId;
+
+pub fn host_header_label_for_machine(machine_id: MachineId) -> String {
+    bech32::encode_without_checksum("carol", machine_id.to_bytes().to_base32()).unwrap()
+}
+
+pub fn parse_host_header_label_for_machine(string: &str) -> Option<MachineId> {
+    let (hrp, data) = bech32::decode_without_checksum(string).ok()?;
+    if hrp != "carol" {
+        return None;
+    }
+    let vec_data = Vec::from_base32(&data).ok()?;
+    Some(MachineId::from_bytes(<[u8; 32]>::try_from(vec_data).ok()?))
+}

--- a/crates/carol_http/src/lib.rs
+++ b/crates/carol_http/src/lib.rs
@@ -9,3 +9,5 @@ extern crate alloc;
 extern crate std;
 
 pub mod api;
+mod host_header;
+pub use host_header::*;

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "advisory-db": {
       "flake": false,
       "locked": {
-        "lastModified": 1686827229,
-        "narHash": "sha256-Z8fcZE2J5hptQeyZqk+FyVCWCEfAZYN18NTVRkAecAk=",
+        "lastModified": 1697318478,
+        "narHash": "sha256-ZEDgHfurZiv9lBGTmHnQ0YECoi6H2NYs3pTo1VU1koQ=",
         "owner": "rustsec",
         "repo": "advisory-db",
-        "rev": "37abf6e46378cb80ef43902a6bd9dcef2d9dfccc",
+        "rev": "71d80e811f2e29a4b82d3e545ad6591e35227e03",
         "type": "github"
       },
       "original": {
@@ -26,11 +26,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1686621798,
-        "narHash": "sha256-FUwWszmSiDzUdTk8f69xwMoYlhdPaLvDaIYOE/y6VXc=",
+        "lastModified": 1697648018,
+        "narHash": "sha256-C7hHmozOpuG4G6/NAnd0/EE1osAzgIV+6eZbuRYtf5U=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "75f7d715f8088f741be9981405f6444e2d49efdd",
+        "rev": "bd2e69ee84552b2befe2594060513ea9e01bfeea",
         "type": "github"
       },
       "original": {
@@ -42,11 +42,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1673956053,
-        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
         "type": "github"
       },
       "original": {
@@ -60,11 +60,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1685518550,
-        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
         "type": "github"
       },
       "original": {
@@ -78,11 +78,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1685518550,
-        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
         "type": "github"
       },
       "original": {
@@ -111,11 +111,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1686776226,
-        "narHash": "sha256-o6WbKvENj98QJz9Mco6T6SZGrjPewMDAFyKg0Lp8avU=",
+        "lastModified": 1697456312,
+        "narHash": "sha256-roiSnrqb5r+ehnKCauPLugoU8S36KgmWraHgRqVYndo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0d2cf7fe5fa05d5271a15a8933414ee0a1570648",
+        "rev": "ca012a02bf8327be9e488546faecae5e05d7d749",
         "type": "github"
       },
       "original": {
@@ -162,11 +162,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1685759304,
-        "narHash": "sha256-I3YBH6MS3G5kGzNuc1G0f9uYfTcNY9NYoRc3QsykLk4=",
+        "lastModified": 1697595136,
+        "narHash": "sha256-9honwiIeMbBKi7FzfEy89f1ShUiXz/gVxZSS048pKyc=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "c535b4f3327910c96dcf21851bbdd074d0760290",
+        "rev": "a2ccfb2134622b28668a274e403ba6f075ae1223",
         "type": "github"
       },
       "original": {
@@ -181,11 +181,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1686882360,
-        "narHash": "sha256-6iWVGIdIzmx/CgXPVLPyyxxBhPGYMl8sG09S8hpQ6pc=",
+        "lastModified": 1697595136,
+        "narHash": "sha256-9honwiIeMbBKi7FzfEy89f1ShUiXz/gVxZSS048pKyc=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "b519b1d7a31f1bd35423990398adecc6f7dd4dd2",
+        "rev": "a2ccfb2134622b28668a274e403ba6f075ae1223",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -29,10 +29,6 @@
                 channel = "stable";
               } // rustupToolchainToml));
 
-              rustToolchain-beta = (super.rust-bin.fromRustupToolchain ({
-                channel = "beta";
-              } // rustupToolchainToml));
-
               rustToolchain-nightly = (super.rust-bin.fromRustupToolchain ({
                 channel = "nightly";
               } // rustupToolchainToml));
@@ -48,7 +44,6 @@
           src = pkgs.lib.cleanSourceWith {
             src = craneLib.path ./.;
             filter = path: type:
-              (pkgs.lib.hasInfix "/resources/" path) ||
               (pkgs.lib.hasSuffix "\.wit" path) ||
               (craneLib.filterCargoSources path type);
           };
@@ -205,12 +200,6 @@
             stable = mkShell {
               buildInputs = [
                 (rustToolchain.override {extensions = devShellToolchainExtensions;})
-              ] ++ devShellPackages;
-            };
-
-            beta = mkShell {
-              buildInputs = [
-                (rustToolchain-beta.override {extensions = devShellToolchainExtensions;})
               ] ++ devShellPackages;
             };
 

--- a/flake.nix
+++ b/flake.nix
@@ -20,13 +20,12 @@
       (system:
         let
           rustupToolchainToml = (readTomlFile ./rust-toolchain.toml).toolchain;
-
           overlays = [
             # use rust overlay to provide a rust toolchain same as rustup would
             (import rust-overlay)
             (self: super: {
               rustToolchain = (super.rust-bin.fromRustupToolchain ({
-                channel = "stable";
+                channel = "1.72.1";
               } // rustupToolchainToml));
 
               rustToolchain-nightly = (super.rust-bin.fromRustupToolchain ({


### PR DESCRIPTION
We want to be able to resolve `www.example.com` to a particular machine but without redirects or anything the user would notice. This allows you to host your website or blog on carol without friction.

To do this. The domain owner sets up a CNAME for `www.example.com` to `<machine-id-as-hex>.<carol-domain>` so `CNAME www.example.com 729e5a06529bb4e93876ef91ab96c6913e65ecb234740096ca46b04a2186f0.carol.computer.` for example. When the carol node receives a request for www.example.com it does the DNS lookup and sees if there's a particular format CNAME, finds the machine by the id and forwards the request to the machine.

I made machine id's 31 bytes long rather than 32 bytes because in order to be a valid domain label it has to be less than 64 bytes long (because of specification weirdness).